### PR TITLE
アコーディオン型タブスタックのバグを修正

### DIFF
--- a/proton/white/proton_white.css
+++ b/proton/white/proton_white.css
@@ -34,9 +34,6 @@ span.title{
     background-color: #E0E0E6;
     border-radius: 3px;
 }
-.tab.active svg{
-    background-color: #F9F9FB;
-}
 .tab.active{
     box-shadow: 0px 0px 100px #BBBBC4;
     outline: solid 1px #BBBBC4;


### PR DESCRIPTION
## 概要
アコーディオン型タブスタックを展開したうえでその左端のタブを選択したときにスタック内が全て白色になるバグを修正しました。  
ただ削除しただけなので別の個所でバグや不適切な動作が起きている可能性も否定できませんのでレビューをお願いします。

##  変更点
`.tab.active svg`を削除

## 特にチェックしていただきたい点
- もともと`.tab.active svg`が担っていた動作がうまく機能しないかもしれない点